### PR TITLE
[fix] user info response after session check

### DIFF
--- a/backend/src/main/java/capstone/offflow/Login/Controller/AuthController.java
+++ b/backend/src/main/java/capstone/offflow/Login/Controller/AuthController.java
@@ -1,26 +1,46 @@
 package capstone.offflow.Login.Controller;
 
+import capstone.offflow.User.Domain.User;
 import capstone.offflow.User.Service.UserPrincipal;
+import capstone.offflow.User.Service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * 1. Session check
  * 2. 인증 상태 확인
  */
 @RestController
+@RequiredArgsConstructor
 @RequestMapping("/api/auth")
 public class AuthController {
 
+    private final UserService userService;
+
     @GetMapping("/check")
-    public ResponseEntity<String> checkSession(
+    public ResponseEntity<?> checkSession(
             @AuthenticationPrincipal UserPrincipal userPrincipal){
         if (userPrincipal == null){
             return ResponseEntity.ok("Not_Logged_in");
         }
-        return ResponseEntity.ok("Logged_in");
+        User user = userService.getUserById(userPrincipal.getUser().getUserId());
+
+        Map<String, String> response = new HashMap<>();
+
+        response.put("userId", user.getUserId());
+        response.put("companyName", user.getCompanyName());
+        response.put("managerName", user.getManagerName());
+        response.put("messageCount", String.valueOf(user.getMessageCount())); //int -> String으로 변환
+        response.put("surveyCount", String.valueOf(user.getSurveyCount()));
+
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
세션 체크 이후 유저 정보 프론트쪽으로 전달

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
- 포스트맨으로 테스트 진행 완료

## Screenshots (if appropriate):
<img width="482" alt="스크린샷 2025-04-10 오후 5 32 10" src="https://github.com/user-attachments/assets/7ebe273a-87c0-4914-8b76-e82d3106327e" />
